### PR TITLE
Removed waste lines

### DIFF
--- a/tools/power/cpupower/utils/helpers/cpuid.c
+++ b/tools/power/cpupower/utils/helpers/cpuid.c
@@ -144,28 +144,13 @@ out:
 		/* Intel's Turbo Ratio Limit support */
 		if (cpu_info->family == 6) {
 			switch (cpu_info->model) {
-			case 0x1A:	/* Core i7, Xeon 5500 series
-					 * Bloomfield, Gainstown NHM-EP
-					 */
-			case 0x1E:	/* Core i7 and i5 Processor
-					 * Clarksfield, Lynnfield, Jasper Forest
-					 */
-			case 0x1F:	/* Core i7 and i5 Processor - Nehalem */
-			case 0x25:	/* Westmere Client
-					 * Clarkdale, Arrandale
-					 */
 			case 0x2C:	/* Westmere EP - Gulftown */
 				cpu_info->caps |= CPUPOWER_CAP_HAS_TURBO_RATIO;
 				break;
-			case 0x2A:	/* SNB */
-			case 0x2D:	/* SNB Xeon */
-			case 0x3A:	/* IVB */
 			case 0x3E:	/* IVB Xeon */
 				cpu_info->caps |= CPUPOWER_CAP_HAS_TURBO_RATIO;
 				cpu_info->caps |= CPUPOWER_CAP_IS_SNB;
 				break;
-			case 0x2E:	/* Nehalem-EX Xeon - Beckton */
-			case 0x2F:	/* Westmere-EX Xeon - Eagleton */
 			default:
 				break;
 			}


### PR DESCRIPTION
If switch contains more than five items, it's implemented using a lookup table or a hash list. Now it doesn't need to create one!
(micro optimization)